### PR TITLE
Increases the time to wait for all services to start

### DIFF
--- a/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMail.java
+++ b/greenmail-core/src/main/java/com/icegreen/greenmail/util/GreenMail.java
@@ -78,8 +78,8 @@ public class GreenMail implements GreenMailOperations {
         }
         //quick hack
         boolean allup = false;
-        final int retries = 100;
-        final int timeoutMsec = 100;
+        final int retries = 200;
+        final int timeoutMsec = 50;
         for (int i = 0; i < retries && !allup; i++) {
             allup = true;
             for (Service service : services.values()) {

--- a/greenmail-core/src/test/java/com/icegreen/greenmail/test/InterruptOnStartupTest.java
+++ b/greenmail-core/src/test/java/com/icegreen/greenmail/test/InterruptOnStartupTest.java
@@ -1,0 +1,26 @@
+package com.icegreen.greenmail.test;
+
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import org.junit.Test;
+
+public class InterruptOnStartupTest {
+
+    /**
+     * Tests that the servers are shut down gracefully when greenmail is
+     * interrupted while starting the mail services.
+     */
+    @Test
+    public void testCleanShutdownWhenInterruptedWhileStartingServices() throws Exception {
+        final Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                GreenMail greenMail = new GreenMail(ServerSetupTest.SMTPS_IMAPS);
+                greenMail.start();
+            }
+        });
+        t.start();
+        Thread.sleep(500);
+        t.interrupt();
+    }
+}


### PR DESCRIPTION
Hey Christian altes Haus /Greenmail team,

this PR increases the total time that com.icegreen.greenmail.util.GreenMail#start waits on isRunning()==true for all services before a RuntimeException is thrown to 10 seconds (was: 1 second).

Background is that I have a test that starts imaps and smtps which takes roughly 1 second. With the old timeout this test would fail sometimes on a slower machine. 
